### PR TITLE
return the filename with any parser error

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -150,7 +150,12 @@ function parseFile(filePath, context) {
 
     var content = options.fileProvider.createFileContent(options.root, filePath, options.encoding);
     var contentAsString = options.fileProvider.getContentAsString(content);
-    var extFile = context.parser.parse(contentAsString, filePath);
+    var extFile;
+    try {
+        extFile = context.parser.parse(contentAsString, filePath);
+    } catch (e) {
+        throw new Error("Error parsing "+filePath+" :\n"+e);
+    }
 
     return {
         path:    filePath,


### PR DESCRIPTION
The parser will exception when you have an error in your javascript such as a missing comma in a component definition. It returns the line number but doesn't give much info to the user about which file it was parsing at the time. I have wrapped the parse step with a try catch to prepend the filename to the exception to help the user with finding the problem.